### PR TITLE
[PM-6890] Modify docs head to include optional "as seen on" attribute

### DIFF
--- a/client/src/theme/DocItem/Content/index.tsx
+++ b/client/src/theme/DocItem/Content/index.tsx
@@ -7,6 +7,7 @@
 
 import clsx from "clsx";
 import { ThemeClassNames } from "@docusaurus/theme-common";
+import { DocFrontMatter } from "@docusaurus/plugin-content-docs";
 import { useDoc } from "@docusaurus/theme-common/internal";
 import Heading from "@theme/Heading";
 import MDXContent from "@theme/MDXContent";
@@ -32,10 +33,13 @@ function useSyntheticTitle(): string | null {
   return metadata.title;
 }
 
+type ExtendedDocFrontMatter = DocFrontMatter & { as_seen_on: string };
+
 export default function DocItemContent({ children }: Props): JSX.Element {
   const syntheticTitle = useSyntheticTitle();
-  const { metadata } = useDoc();
+  const { metadata, frontMatter } = useDoc();
   const docDescription = metadata.description;
+  const { as_seen_on: asSeenOn } = frontMatter as ExtendedDocFrontMatter;
 
   return (
     <div className={clsx(ThemeClassNames.docs.docMarkdown, "markdown")}>
@@ -45,7 +49,16 @@ export default function DocItemContent({ children }: Props): JSX.Element {
             <>
               <Heading as="h1">{syntheticTitle}</Heading>
               <br />
-              <small>{metadata.description}</small>
+              {asSeenOn && (
+                <>
+                  <small>
+                    <em>(As seen on {asSeenOn})</em>
+                  </small>
+                  <br />
+                  <br />
+                </>
+              )}
+              <div>{metadata.description}</div>
             </>
           ) : (
             <Heading as="h1">{syntheticTitle}</Heading>


### PR DESCRIPTION
## 🚧 Type of change

-  🚀 New feature development

## 📔 Objective

These changes add a "as seen on" statement at the head of document pages if the `as_seen_on` attribute is present in the doc front matter.

![Screenshot 2024-03-19 at 4 42 49 PM](https://github.com/bitwarden/test-the-web/assets/1556494/a7133cef-b27e-419a-a1a2-f8e47ece9185)
