### PR TITLE
[PM-7950] Build workflow should use the provided TEST_WEB_HOST env variable if available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Clean install dependencies and build
         run: |
           npm ci
+          export TEST_WEB_HOST="${{ secrets.TEST_WEB_HOST || 'https://localhost' }}"
           npm run build
 
       - name: Upload build as artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,10 @@ jobs:
           node-version: "20"
 
       - name: Clean install dependencies and build
+        env:
+          TEST_WEB_HOST: "${{ secrets.TEST_WEB_HOST || 'https://localhost' }}"
         run: |
           npm ci
-          export TEST_WEB_HOST="${{ secrets.TEST_WEB_HOST || 'https://localhost' }}"
           npm run build
 
       - name: Upload build as artifact


### PR DESCRIPTION
## 🎟️ Tracking

PM-7950

## 📔 Objective

Any environment variable consumed by docusaurus (with [a few exceptions](https://docusaurus.io/docs/advanced/ssg#node-env)) need to be available at build time

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
