### PR TITLE
doc: fix grammar in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@ Bitwarden believes that working with security researchers across the globe is cr
 - Let us know as soon as possible upon discovery of a potential security issue, and we'll make every effort to quickly resolve the issue.
 - Provide us a reasonable amount of time to resolve the issue before any disclosure to the public or a third-party. We may publicly disclose the issue before resolving it, if appropriate.
 - Make a good faith effort to avoid privacy violations, destruction of data, and interruption or degradation of our service. Only interact with accounts you own or with explicit permission of the account holder.
-- If you would like to encrypt your report, please use the PGP key with long ID `0xDE6887086F892325FEC04CC0D847525B6931381F` (available in the public keyserver pool).
+- To encrypt your report, please use the PGP key with the long ID `0xDE6887086F892325FEC04CC0D847525B6931381F`, which is available in the public keyserver pool.
 
 While researching, we'd like to ask you to refrain from:
 


### PR DESCRIPTION
<!--
Testing for https://hackerone.com/reports/2520872
Test default first-time-contributor rules
-->

This PR updates the grammar in the SECURITY.md file, so that the users can better understand the PGP key.