### PR TITLE
[PM-8469] Add case for a payment form in an iframe

### DIFF
--- a/client/docs/forms/payment/card-payment.md
+++ b/client/docs/forms/payment/card-payment.md
@@ -2,6 +2,7 @@
 slug: card-payment
 title: card payment form
 sidebar_label: card
+sidebar_position: 1
 description: a card payment form that will POST the input values on submit
 ---
 

--- a/client/docs/forms/payment/iframe-payment.md
+++ b/client/docs/forms/payment/iframe-payment.md
@@ -1,0 +1,17 @@
+---
+slug: iframe-payment
+title: iframe payment form
+sidebar_label: iframe
+sidebar_position: 2
+description: a payment form nested within an inline frame (iframe) that will POST on submit
+---
+
+<iframe
+  id="test-iframe"
+  src="/payment-page-bare?docusaurus-data-bare-page=true"
+  class="margin-vert--lg"
+  style="overflow-y: hidden; width: 100%; height: 480px;"
+  scrolling="no"
+></iframe>
+
+<hr/>

--- a/client/src/pages/payment-page-bare.md
+++ b/client/src/pages/payment-page-bare.md
@@ -1,0 +1,71 @@
+---
+slug: payment-page-bare
+title: Payment
+description: basic payment form used for easy embedding via iframe
+---
+
+<div class="card col col--12 padding--md">
+  <form
+    class="card__body"
+    method="POST"
+    action="/payment"
+  >
+    <div class="row">
+      <div class="col col--12 margin-bottom--md">
+        <label for="card-name">Name on card</label>
+        <br/>
+        <input
+          type="text"
+          name="card-name"
+          id="card-name"
+          placeholder="J. Smith"
+          required
+        />
+      </div>
+      <div class="col col--12 margin-bottom--md">
+        <label for="card-number">Credit card number</label>
+        <br/>
+        <input
+          type="text"
+          name="card-number"
+          id="card-number"
+          placeholder="1234567890123456"
+          maxlength="19"
+          pattern="\d{12,19}"
+          title="a digit value between 12 and 19 characters in length"
+          required
+        />
+      </div>
+      <div class="col col--5 margin-bottom--md">
+        <label for="card-expiration">Expiration</label>
+        <br/>
+        <input
+          type="text"
+          name="card-expiration"
+          id="card-expiration"
+          placeholder="01/29"
+          maxlength="5"
+          pattern="\d{2}\/\d{2}"
+          title="a month / year date formatted as mm/yy"
+          required
+        />
+      </div>
+      <div class="col col--5 margin-bottom--md">
+        <label for="card-cvv">CVV</label>
+        <br/>
+        <input
+          type="text"
+          name="card-cvv"
+          id="card-cvv"
+          placeholder="000"
+          maxlength="4"
+          pattern="\d{3,4}"
+          title="a 3-4 digit value"
+          required
+        />
+      </div>
+    </div>
+    <hr/>
+    <button type="submit" class="button button--primary">Submit</button>
+  </form>
+</div>


### PR DESCRIPTION
## 🎟️ Tracking

PM-8469

## 📔 Objective

Let’s add a payment form within an iframe to cover this common pattern:

"a lot of credit card forms are implemented in an iframe for PCI compliance"

## 📸 Screenshots

![Screenshot 2024-05-29 at 10 38 00 AM](https://github.com/bitwarden/test-the-web/assets/1556494/c5b033ab-b4e2-4b08-90f8-c62e3dcc079e)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
