### PR TITLE
[PM-12775] Add pattern for single input security code input

### DIFF
--- a/client/docs/forms/login/security-code-multi-input.mdx
+++ b/client/docs/forms/login/security-code-multi-input.mdx
@@ -1,6 +1,7 @@
 ---
 slug: security-code-multi-input
-title: multi-input security code
+title: security code (multi-input)
+sidebar_position: 21
 description: A form that requires a security code with each numerical digit as it's own input
 as_seen_on: PayPal login
 ---

--- a/client/docs/forms/login/security-code.md
+++ b/client/docs/forms/login/security-code.md
@@ -1,0 +1,47 @@
+---
+slug: security-code
+title: security code
+sidebar_position: 20
+description: A form that requires a security code
+as_seen_on: Bitwarden login
+---
+
+<div class="container margin-vert--xl">
+  <div class="row">
+    <div class="card col col--12 padding--md">
+      <form
+        class="card__body"
+        method="POST"
+        action="/login"
+      >
+        <div class="row">
+          <div class="col col--12 margin-bottom--md">
+            <label class="tw-mb-1 tw-block tw-font-semibold tw-text-main" for="input-3">
+              <span>Verification code</span>
+              <small> (required)</small>
+            </label>
+            <br />
+            <input
+              autocapitalize="none"
+              autocomplete="off"
+              autocorrect="none"
+              id="input-3"
+              inputmode="verbatim"
+              name="input-3"
+              type="password"
+              required
+            />
+          </div>
+          <div class="col col--12 margin-bottom--md">
+          <button
+            type="submit"
+            class="col col--4 button button--primary"
+          >
+            <span>Continue</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<hr />


### PR DESCRIPTION
## 🎟️ Tracking

PM-12775

## 📔 Objective

This adds a pattern for single input security code input, using the Bitwarden vault login components as reference.

This allows us to confirm and continually test the change autofilling behaviour introduced in PM-12775

## 📸 Screenshots

![Screenshot 2024-10-02 at 10 45 04 AM](https://github.com/user-attachments/assets/63b3af44-774e-4370-bb1f-511a6b9989a5)

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
