### PR TITLE
[PM-12775] Add pattern for single-input security code field intended to be filled by a device

### DIFF
--- a/client/docs/forms/login/security-code-device.md
+++ b/client/docs/forms/login/security-code-device.md
@@ -1,8 +1,8 @@
 ---
-slug: security-code
-title: security code
-sidebar_position: 20
-description: A form that expects an authenticator security code
+slug: security-code-device
+title: security code (device)
+sidebar_position: 21
+description: A form that expects a code filled by a security HID
 as_seen_on: Bitwarden login
 ---
 
@@ -16,7 +16,7 @@ as_seen_on: Bitwarden login
       >
         <div class="row">
           <div class="col col--12 margin-bottom--md">
-            <label class="tw-mb-1 tw-block tw-font-semibold tw-text-main" for="input-3">
+            <label class="tw-mb-1 tw-block tw-font-semibold tw-text-main" for="input-4">
               <span>Verification code</span>
               <small> (required)</small>
             </label>
@@ -25,10 +25,10 @@ as_seen_on: Bitwarden login
               autocapitalize="none"
               autocomplete="off"
               autocorrect="none"
-              id="input-3"
+              id="input-4"
               inputmode="verbatim"
-              name="input-3"
-              type="text"
+              name="input-4"
+              type="password"
               required
             />
           </div>

--- a/client/docs/forms/login/security-code-multi-input.mdx
+++ b/client/docs/forms/login/security-code-multi-input.mdx
@@ -1,7 +1,7 @@
 ---
 slug: security-code-multi-input
 title: security code (multi-input)
-sidebar_position: 21
+sidebar_position: 22
 description: A form that requires a security code with each numerical digit as it's own input
 as_seen_on: PayPal login
 ---


### PR DESCRIPTION
## 🎟️ Tracking

PM-12775

## 📔 Objective

This adds a pattern for single input security code input to be filled by a security HID (e.g. Yubikey), as opposed to an authenticator.

This allows us to confirm and continually test the change autofilling behaviour introduced in PM-12775

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
