### PR TITLE
Allow LoginForm to have a configurable number, variety, order of steps.

### DIFF
--- a/client/docs/forms/login/multi-step-login-no-username.mdx
+++ b/client/docs/forms/login/multi-step-login-no-username.mdx
@@ -1,0 +1,21 @@
+---
+slug: multi-step-login-no-username
+title: multi-step login form (no username)
+sidebar_label: multi-step login form (no username)
+sidebar_position: 12
+description: a multi-step form (with no username field) will store user inputs of each step and will POST on final submit
+---
+
+import { LoginForm, FormSteps } from "@site/src/components/LoginForm";
+
+<div className="container margin-vert--xl">
+  <div className="row">
+    <div className="card col col--12 padding--md">
+      <LoginForm
+        action="/login"
+        formSteps={[FormSteps.Email, FormSteps.Password]}
+      />
+    </div>
+  </div>
+</div>
+<hr />

--- a/client/docs/forms/login/multi-step-login.mdx
+++ b/client/docs/forms/login/multi-step-login.mdx
@@ -6,12 +6,15 @@ sidebar_position: 8
 description: a multi-step form will store user inputs of each step and will POST on final submit
 ---
 
-import { LoginForm } from "@site/src/components/LoginForm";
+import { LoginForm, FormSteps } from "@site/src/components/LoginForm";
 
 <div className="container margin-vert--xl">
   <div className="row">
     <div className="card col col--12 padding--md">
-      <LoginForm action="/login" isMultiStep={true} />
+      <LoginForm
+        action="/login"
+        formSteps={[FormSteps.Username, FormSteps.Email, FormSteps.Password]}
+      />
     </div>
   </div>
 </div>

--- a/client/src/components/HiddenLogin.tsx
+++ b/client/src/components/HiddenLogin.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
 import { keyframes } from "@emotion/react";
-import { LoginForm } from "@site/src/components/LoginForm";
+import { FormSteps, LoginForm } from "@site/src/components/LoginForm";
 
 export function HiddenLogin() {
   const [showLogin, setShowLogin] = useState(false);
@@ -22,7 +22,14 @@ export function HiddenLogin() {
       </div>
       {showLogin && (
         <ZoomAndFadeInLoginFormContainer>
-          <LoginForm action="/login" isMultiStep={true} />
+          <LoginForm
+            action="/login"
+            formSteps={[
+              FormSteps.Username,
+              FormSteps.Email,
+              FormSteps.Password,
+            ]}
+          />
         </ZoomAndFadeInLoginFormContainer>
       )}
     </div>

--- a/client/src/components/Inputs.tsx
+++ b/client/src/components/Inputs.tsx
@@ -1,4 +1,4 @@
-import { RefObject } from "react";
+import { FormEvent, ReactEventHandler, RefObject } from "react";
 
 export function UsernameInput({
   inputRef,
@@ -69,7 +69,7 @@ export function SubmitButton({
   handleSelect,
   label,
 }: {
-  handleSelect?: () => void;
+  handleSelect?: ReactEventHandler;
   label: string;
 }) {
   return (


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15436](https://bitwarden.atlassian.net/browse/PM-15436)

## 📔 Objective

To allow us to handle complex scenarios such as filling in a multi-step form even when X field is not present, webtests should allow us to easily build login forms that handle a variety of scenarios. In this case, multi-step login forms can be generated from an array configuration like so:

```
[FormSteps.Username, FormSteps.Password]
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15436]: https://bitwarden.atlassian.net/browse/PM-15436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ