### PR TITLE
[PM-25209] Added security-code signposted page

### DIFF
--- a/client/docs/forms/login/security-code-signposted.md
+++ b/client/docs/forms/login/security-code-signposted.md
@@ -9,14 +9,13 @@ as_seen_on: Bitwarden login
 <div class="container margin-vert--xl">
   <div class="row">
     <div class="card col col--12 padding--md">
-      <form
-        class="card__body"
-        method="POST"
-        action="/login"
-      >
+      <form class="card__body" method="POST" action="/login">
         <div class="row">
           <div class="col col--12 margin-bottom--md">
-            <label class="tw-mb-1 tw-block tw-font-semibold tw-text-main" for="input-3">
+            <label
+              class="tw-mb-1 tw-block tw-font-semibold tw-text-main"
+              for="input-3"
+            >
               <span>Verification code</span>
               <small> (required)</small>
             </label>
@@ -33,12 +32,10 @@ as_seen_on: Bitwarden login
             />
           </div>
           <div class="col col--12 margin-bottom--md">
-          <button
-            type="submit"
-            class="col col--4 button button--primary"
-          >
-            <span>Continue</span>
-          </button>
+            <button type="submit" class="col col--4 button button--primary">
+              <span>Continue</span>
+            </button>
+          </div>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25209](https://bitwarden.atlassian.net/browse/PM-25209)

## 📔 Objective

Add Security code page but with the field signposted to have the ideal scenario for OTP autofill, specially useful for the iOS Autofill extension where the OS requires the field to be configured correctly with `autocomplete="one-time-code"` in order to fire the appropriate request to the autofill extension.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25209]: https://bitwarden.atlassian.net/browse/PM-25209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ