### PR TITLE
Add subscribe/login pages for heading cases

### DIFF
--- a/client/docs/forms/multi-step/multi-step-login-with-newsletter-sibling.md
+++ b/client/docs/forms/multi-step/multi-step-login-with-newsletter-sibling.md
@@ -1,0 +1,44 @@
+---
+slug: login-with-newsletter-sibling
+title: sign-in form alongside a newsletter opt-in card
+sidebar_label: sibling newsletter
+description: a single-step email sign-in form and a separate newsletter opt-in card (heading + checkbox) rendered in adjacent rows of the same container
+---
+
+<div class="container margin-vert--xl">
+  <div class="row">
+    <div class="card col col--12 padding--md">
+      <h3>Sign in</h3>
+      <form
+        class="card__body"
+        method="POST"
+        action="/login"
+        id="signin-form"
+      >
+        <div class="row margin-bottom--md">
+          <label for="email" class="margin-right--sm">Email</label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            placeholder="you@example.com"
+            required
+          />
+        </div>
+        <div class="row">
+          <button type="submit" class="button button--primary">Continue</button>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="row">
+    <div class="card col col--12 padding--md">
+      <h3>Subscribe to our newsletter</h3>
+      <label>
+        <input type="checkbox" name="newsletter-opt-in" />
+        I'd like to receive periodic updates.
+      </label>
+    </div>
+  </div>
+</div>
+<hr/>

--- a/client/docs/forms/subscribe/newsletter-by-heading.md
+++ b/client/docs/forms/subscribe/newsletter-by-heading.md
@@ -1,0 +1,35 @@
+---
+slug: newsletter-by-heading
+title: newsletter subscribe form with generic form and field attributes
+sidebar_label: generic attrs
+description: a newsletter signup form whose `<form>` and email input attributes use generic names (`contact-form`, `email-address`, `/api/save`); the form is preceded by an `<h3>Newsletter</h3>` heading
+---
+
+<div class="container margin-vert--xl">
+  <div class="row">
+    <div class="card col col--12 padding--md">
+      <h3>Newsletter</h3>
+      <form
+        class="card__body"
+        method="POST"
+        action="/api/save"
+        id="contact-form"
+      >
+        <div class="row margin-bottom--md">
+          <label for="email-address" class="margin-right--sm">Email address</label>
+          <input
+            type="email"
+            id="email-address"
+            name="contact-email"
+            placeholder="you@example.com"
+            required
+          />
+        </div>
+        <div class="row">
+          <button type="submit" class="button button--primary">Sign up</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<hr/>

--- a/client/docs/forms/subscribe/newsletter-opaque-id.md
+++ b/client/docs/forms/subscribe/newsletter-opaque-id.md
@@ -2,7 +2,7 @@
 slug: newsletter-opaque-id
 title: newsletter subscribe form with opaque field id
 sidebar_label: opaque id
-description: a newsletter signup form whose email field has no username-related keywords in its `id`, `name`, or `label` — only `type="email"` signals its purpose.
+description: a newsletter signup form whose email field uses an `id`, `name`, and `label` unrelated to its purpose (`id="notification-address"`, `name="contact"`, `label="Sign up for updates"`); only `type="email"` indicates the field type.
 ---
 
 <div class="container margin-vert--xl">


### PR DESCRIPTION
## 🎟️ Tracking

As related to [PM-33789](https://bitwarden.atlassian.net/browse/PM-33789)

## 📔 Objective

Handles two patterns which illustrate ambiguity in form content mediated by headings.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[PM-33789]: https://bitwarden.atlassian.net/browse/PM-33789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ