### PR TITLE
make autofilled values in closed shadow roots observable

### DIFF
--- a/client/docs/forms/login/shadow-root-inputs-closed.md
+++ b/client/docs/forms/login/shadow-root-inputs-closed.md
@@ -2,7 +2,7 @@
 slug: shadow-root-inputs-closed
 title: closed shadow-root inputs form
 sidebar_label: shadow-root inputs (closed)
-description: a basic login form within an open shadow-root with inputs within closed shadow-roots. The form will POST the input values on submit
+description: a basic login form within an open shadow-root with inputs within closed shadow-roots. The form will POST the input values on submit. Values in the closed shadow root inputs are mirrored to transparent output nodes for programmatic observability.
 ---
 
 <script src="/js/build-shadow-root-form.js" defer="defer"></script>

--- a/client/static/js/build-shadow-root-form.js
+++ b/client/static/js/build-shadow-root-form.js
@@ -37,7 +37,18 @@
   usernameInput.required = true;
 
   usernameShadow.appendChild(usernameInput);
-  usernameContainer.append(usernameLabel, usernameShadowHost);
+
+  // Mirror for Playwright observability — closed shadow roots aren't queryable from outside
+  const usernameMirror = document.createElement("output");
+  usernameMirror.setAttribute("data-mirror", "username");
+  usernameInput.addEventListener("input", () => {
+    usernameMirror.textContent = usernameInput.value;
+  });
+  usernameInput.addEventListener("change", () => {
+    usernameMirror.textContent = usernameInput.value;
+  });
+
+  usernameContainer.append(usernameLabel, usernameShadowHost, usernameMirror);
 
   // Password field container
   const passwordContainer = document.createElement("div");
@@ -56,7 +67,18 @@
   passwordInput.required = true;
 
   passwordShadow.appendChild(passwordInput);
-  passwordContainer.append(passwordLabel, passwordShadowHost);
+
+  // Mirror for Playwright observability — closed shadow roots aren't queryable from outside
+  const passwordMirror = document.createElement("output");
+  passwordMirror.setAttribute("data-mirror", "password");
+  passwordInput.addEventListener("input", () => {
+    passwordMirror.textContent = passwordInput.value;
+  });
+  passwordInput.addEventListener("change", () => {
+    passwordMirror.textContent = passwordInput.value;
+  });
+
+  passwordContainer.append(passwordLabel, passwordShadowHost, passwordMirror);
 
   // Submit button container
   const buttonContainer = document.createElement("div");

--- a/client/static/js/build-shadow-root-form.js
+++ b/client/static/js/build-shadow-root-form.js
@@ -38,7 +38,7 @@
 
   usernameShadow.appendChild(usernameInput);
 
-  // Mirror for Playwright observability — closed shadow roots aren't queryable from outside
+  // Mirror for observability — closed shadow roots aren't queryable from outside
   const usernameMirror = document.createElement("output");
   usernameMirror.setAttribute("data-mirror", "username");
   usernameInput.addEventListener("input", () => {
@@ -68,7 +68,7 @@
 
   passwordShadow.appendChild(passwordInput);
 
-  // Mirror for Playwright observability — closed shadow roots aren't queryable from outside
+  // Mirror for observability — closed shadow roots aren't queryable from outside
   const passwordMirror = document.createElement("output");
   passwordMirror.setAttribute("data-mirror", "password");
   passwordInput.addEventListener("input", () => {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35399

## 📔 Objective

Playwright cannot inspect closed shadow roots; the mirror reflects changes made within the shadow root to an `<output>` adjacent to the control.

## 🎥 Demo

https://github.com/user-attachments/assets/14b68553-f204-40c4-885b-aab06a1dc505

Updated copy:
<img width="999" height="427" alt="image" src="https://github.com/user-attachments/assets/032dba53-1cb2-48aa-a08e-95d3cd9fb335" />
