### PR TITLE
[PM-39438] feat: Add create account flow with passwordrules

### DIFF
--- a/client/docs/forms/create/account-passwordrules.md
+++ b/client/docs/forms/create/account-passwordrules.md
@@ -3,10 +3,23 @@ slug: create-account-passwordrules
 title: account creation form with passwordrules
 sidebar_label: account (passwordrules)
 sidebar_position: 2
-description: a sign up form requiring an email and password - supports dynamic passwordrules attribute on the password field
+description: a sign up form requiring an email and password - supports dynamic `passwordrules` attribute on the password field
 ---
 
 <script src="/js/account-passwordrules.js" defer="defer"></script>
+
+<div class="col col--12 margin-vert--lg hide-on-bare-page">
+  <label for="passwordrules-input">
+    Password rules (<a href="https://github.com/whatwg/html/issues/3518">HTML definition</a>)
+  </label>
+  <br/>
+  <input
+    id="passwordrules-input"
+    placeholder="e.g. minlength: 20; required: upper; required: digit;"
+    type="text"
+    style="width: 100%"
+  />
+</div>
 
 <div class="container margin-vert--xl">
   <div class="row">
@@ -27,17 +40,6 @@ description: a sign up form requiring an email and password - supports dynamic p
               placeholder="e.g. jsmith@example.com"
               required
               type="text"
-            />
-          </div>
-          <div class="col col--12 margin-bottom--md">
-            <label for="passwordrules-input">Password rules</label>
-            <br/>
-            <input
-              id="passwordrules-input"
-              name="passwordrules-input"
-              placeholder="e.g. minlength: 20; required: upper; required: digit;"
-              type="text"
-              style={{width: "100%"}}
             />
           </div>
           <div class="col col--12 margin-bottom--lg">

--- a/client/docs/forms/create/account-passwordrules.md
+++ b/client/docs/forms/create/account-passwordrules.md
@@ -1,0 +1,63 @@
+---
+slug: create-account-passwordrules
+title: account creation form with passwordrules
+sidebar_label: account (passwordrules)
+sidebar_position: 2
+description: a sign up form requiring an email and password - supports dynamic passwordrules attribute on the password field
+---
+
+<script src="/js/account-passwordrules.js" defer="defer"></script>
+
+<div class="container margin-vert--xl">
+  <div class="row">
+    <div class="card col col--12 padding--md">
+      <form
+        class="card__body"
+        method="POST"
+        action="/account"
+      >
+        <div class="row">
+          <div class="col col--12 margin-bottom--md">
+            <label for="email">Enter the email you'd like to create an account with</label>
+            <br/>
+            <input
+              autocomplete="email"
+              id="email"
+              name="email"
+              placeholder="e.g. jsmith@example.com"
+              required
+              type="text"
+            />
+          </div>
+          <div class="col col--12 margin-bottom--md">
+            <label for="passwordrules-input">Password rules</label>
+            <br/>
+            <input
+              id="passwordrules-input"
+              name="passwordrules-input"
+              placeholder="e.g. minlength: 20; required: upper; required: digit;"
+              type="text"
+              style={{width: "100%"}}
+            />
+          </div>
+          <div class="col col--12 margin-bottom--lg">
+            <label for="password">Create a password</label>
+            <br/>
+            <input
+              autocomplete="new-password"
+              id="password"
+              name="password"
+              passwordrules="minlength: 20; required: upper; required: digit;"
+              required
+              type="password"
+            />
+          </div>
+          <div class="col col--12">
+            <button type="submit" class="button button--primary">Sign up</button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+<hr/>

--- a/client/static/js/account-passwordrules.js
+++ b/client/static/js/account-passwordrules.js
@@ -1,0 +1,14 @@
+!(function () {
+  const rulesInput = document.getElementById("passwordrules-input");
+  const passwordInput = document.getElementById("password");
+
+  if (!rulesInput || !passwordInput) {
+    return;
+  }
+
+  rulesInput.value = passwordInput.getAttribute("passwordrules") || "";
+
+  rulesInput.addEventListener("input", function () {
+    passwordInput.setAttribute("passwordrules", rulesInput.value);
+  });
+})();

--- a/client/static/js/account-passwordrules.js
+++ b/client/static/js/account-passwordrules.js
@@ -8,7 +8,11 @@
 
   rulesInput.value = passwordInput.getAttribute("passwordrules") || "";
 
+  let debounceTimer;
   rulesInput.addEventListener("input", function () {
-    passwordInput.setAttribute("passwordrules", rulesInput.value);
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(function () {
+      passwordInput.setAttribute("passwordrules", rulesInput.value);
+    }, 300);
   });
 })();

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -2,6 +2,7 @@ Bitwarden
 dotfile
 jsmith
 keyserver
+passwordrules
 sandboxed
 TOTP
 typeless


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39438](https://bitwarden.atlassian.net/browse/PM-39438)

## 📔 Objective

Add create account flow with [passwordrules](https://github.com/whatwg/html/issues/3518) attribute in the password and a field to modify passwordrules dynamically applying them to the password.
This is helpful to test flows for [PM-29546](https://bitwarden.atlassian.net/browse/PM-29546)

## 📸 Screenshots

<img width="1060" height="510" alt="image" src="https://github.com/user-attachments/assets/17b854da-9034-46b6-a558-00452ae51cd7" />




[PM-39438]: https://bitwarden.atlassian.net/browse/PM-39438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-29546]: https://bitwarden.atlassian.net/browse/PM-29546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ